### PR TITLE
Makefile for Raspberry/Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 CC := gcc
 CXX := g++
-CFLAGS += -Isrc -Wall
+CFLAGS += -Isrc -Wall -std=gnu99
 CXXFLAGS += -Isrc -std=c++0x -Wall -Wno-sign-compare \
     -Wno-unused-local-typedefs -Winit-self -rdynamic \
     -DHAVE_POSIX_MEMALIGN


### PR DESCRIPTION
added "-std=gnu99" to CFLAGS so that it compiles on Debian Jessie / Raspberry Pi (and probably most other Linux/Unix systems).